### PR TITLE
Fix key pruning & rotation

### DIFF
--- a/plugin/backend_test.go
+++ b/plugin/backend_test.go
@@ -18,6 +18,7 @@ package jwtsecrets
 
 import (
 	"context"
+	"github.com/go-test/deep"
 	"github.com/google/uuid"
 	"github.com/hashicorp/vault/sdk/logical"
 	"testing"
@@ -38,10 +39,211 @@ func getTestBackend(t *testing.T) (*backend, *logical.Storage) {
 		t.Fatalf("unable to create backend: %v", err)
 	}
 
-	b.clock = &fakeClock{time.Unix(0, 0)}
 	b.idGen = &fakeIDGenerator{0}
 
 	_ = b.clearConfig(context.Background(), config.StorageView)
 
 	return b, &config.StorageView
+}
+
+func TestRotate(t *testing.T) {
+	b, storage := getTestBackend(t)
+
+	_, err := writeConfig(b, storage, map[string]interface{}{
+		keyRotationDuration: "2s",
+		keyTokenTTL:         "1s",
+	})
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	err = writeRole(b, storage, "tester", "tester.example.com", map[string]interface{}{}, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	config, err := b.getConfig(context.Background(), *storage)
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	policy, err := b.getPolicy(context.Background(), *storage, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	// Pre-rotate checks
+	if diff := deep.Equal(policy.LatestVersion, 1); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+	if diff := deep.Equal(policy.MinAvailableVersion, 0); diff != nil {
+		t.Error("policy min-available version", diff)
+	}
+	if diff := deep.Equal(policy.MinDecryptionVersion, 1); diff != nil {
+		t.Error("policy min-decryption version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveVersion, 1); diff != nil {
+		t.Error("policy archive version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveMinVersion, 0); diff != nil {
+		t.Error("policy archive-min version", diff)
+	}
+
+	time.Sleep(config.KeyRotationPeriod + 1)
+
+	// Post-rotate #1 checks
+	policy, err = b.getPolicy(context.Background(), *storage, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	if diff := deep.Equal(policy.LatestVersion, 2); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+	if diff := deep.Equal(policy.MinAvailableVersion, 0); diff != nil {
+		t.Error("policy min-available version", diff)
+	}
+	if diff := deep.Equal(policy.MinDecryptionVersion, 1); diff != nil {
+		t.Error("policy min-decryption version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveVersion, 2); diff != nil {
+		t.Error("policy archive version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveMinVersion, 0); diff != nil {
+		t.Error("policy archive-min version", diff)
+	}
+
+	policy, err = b.getPolicy(context.Background(), *storage, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	// Should not have rotated yet
+	if diff := deep.Equal(policy.LatestVersion, 2); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+	if diff := deep.Equal(policy.MinAvailableVersion, 0); diff != nil {
+		t.Error("policy min-available version", diff)
+	}
+	if diff := deep.Equal(policy.MinDecryptionVersion, 1); diff != nil {
+		t.Error("policy min-decryption version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveVersion, 2); diff != nil {
+		t.Error("policy archive version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveMinVersion, 0); diff != nil {
+		t.Error("policy archive-min version", diff)
+	}
+
+	time.Sleep(config.KeyRotationPeriod + 1)
+
+	policy, err = b.getPolicy(context.Background(), *storage, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	// Post-rotate #2 checks
+	if diff := deep.Equal(policy.LatestVersion, 3); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+	if diff := deep.Equal(policy.MinAvailableVersion, 0); diff != nil {
+		t.Error("policy min-available version", diff)
+	}
+	if diff := deep.Equal(policy.MinDecryptionVersion, 1); diff != nil {
+		t.Error("policy min-decryption version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveVersion, 3); diff != nil {
+		t.Error("policy archive version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveMinVersion, 0); diff != nil {
+		t.Error("policy archive-min version", diff)
+	}
+}
+
+func TestPrune(t *testing.T) {
+	b, storage := getTestBackend(t)
+
+	_, err := writeConfig(b, storage, map[string]interface{}{
+		keyRotationDuration: "2s",
+		keyTokenTTL:         "1s",
+	})
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	err = writeRole(b, storage, "tester", "tester.example.com", map[string]interface{}{}, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	config, err := b.getConfig(context.Background(), *storage)
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	policy, err := b.getPolicy(context.Background(), *storage, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+	if diff := deep.Equal(policy.LatestVersion, 1); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+
+	time.Sleep(config.KeyRotationPeriod + 1)
+
+	policy, err = b.getPolicy(context.Background(), *storage, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+	if diff := deep.Equal(policy.LatestVersion, 2); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+
+	time.Sleep(config.KeyRotationPeriod + 1)
+
+	policy, err = b.getPolicy(context.Background(), *storage, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+	if diff := deep.Equal(policy.LatestVersion, 3); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+
+	time.Sleep(config.KeyRotationPeriod + config.TokenTTL + 1)
+
+	err = b.pruneKeyVersions(context.Background(), *storage, policy, config, "test")
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	// Post-prune checks
+	if diff := deep.Equal(policy.LatestVersion, 3); diff != nil {
+		t.Error("policy latest version", diff)
+	}
+	if diff := deep.Equal(policy.MinAvailableVersion, 3); diff != nil {
+		t.Error("policy min-available version", diff)
+	}
+	if diff := deep.Equal(policy.MinDecryptionVersion, 3); diff != nil {
+		t.Error("policy min-decryption version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveVersion, 3); diff != nil {
+		t.Error("policy archive version", diff)
+	}
+	if diff := deep.Equal(policy.ArchiveMinVersion, 3); diff != nil {
+		t.Error("policy archive-min version", diff)
+	}
+
+	time.Sleep(config.KeyRotationPeriod)
+
+	// Check that JWKS set contains the correct key versions.
+	// Should be 2 keys because pruning should have reduced it to 1 version
+	// and fetching will rotate again, leaving two keys.
+	jwks, err := FetchJWKS(b, storage)
+	if err != nil {
+		t.Fatalf("%s\n", err)
+	}
+
+	if diff := deep.Equal(len(jwks.Keys), 2); diff != nil {
+		t.Error("jwks key count", diff)
+	}
 }

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -147,7 +147,7 @@ func (c *Config) copy() *Config {
 	return &cc
 }
 
-func (b *backend) saveConfig(ctx context.Context, stg logical.Storage, config *Config) error {
+func (b *backend) saveConfig(ctx context.Context, stg logical.Storage, config *Config, mount string) error {
 	b.cachedConfigLock.Lock()
 	defer b.cachedConfigLock.Unlock()
 
@@ -166,7 +166,7 @@ func (b *backend) saveConfig(ctx context.Context, stg logical.Storage, config *C
 
 	b.Logger().Info("Key Format Rotation")
 
-	policy, err := b.getPolicy(ctx, stg, config)
+	policy, err := b.getPolicy(ctx, stg, config, mount)
 	if err != nil {
 		return err
 	}

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -234,7 +234,7 @@ func (b *backend) pathConfigWrite(ctx context.Context, req *logical.Request, d *
 		return logical.ErrorResponse("'%s' is greater that the max lease ttl", keyTokenTTL), logical.ErrInvalidRequest
 	}
 
-	if err := b.saveConfig(ctx, req.Storage, config); err != nil {
+	if err := b.saveConfig(ctx, req.Storage, config, req.MountPoint); err != nil {
 		return nil, err
 	}
 

--- a/plugin/path_config_test.go
+++ b/plugin/path_config_test.go
@@ -35,10 +35,11 @@ const (
 func writeConfig(b *backend, storage *logical.Storage, config map[string]interface{}) (*logical.Response, error) {
 
 	req := &logical.Request{
-		Operation: logical.UpdateOperation,
-		Path:      "config",
-		Storage:   *storage,
-		Data:      config,
+		Operation:  logical.UpdateOperation,
+		Path:       "config",
+		Storage:    *storage,
+		Data:       config,
+		MountPoint: "test",
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)
@@ -55,9 +56,10 @@ func TestDefaultConfig(t *testing.T) {
 	b, storage := getTestBackend(t)
 
 	req := &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "config",
-		Storage:   *storage,
+		Operation:  logical.ReadOperation,
+		Path:       "config",
+		Storage:    *storage,
+		MountPoint: "test",
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)

--- a/plugin/path_jwks.go
+++ b/plugin/path_jwks.go
@@ -43,7 +43,7 @@ func pathJwks(b *backend) *framework.Path {
 
 func (b *backend) pathJwksRead(ctx context.Context, req *logical.Request, _ *framework.FieldData) (*logical.Response, error) {
 
-	jwkSet, err := b.getPublicKeys(ctx, req.Storage)
+	jwkSet, err := b.getPublicKeys(ctx, req.Storage, req.MountPoint)
 	if err != nil {
 		return nil, err
 	}
@@ -63,14 +63,14 @@ func (b *backend) pathJwksRead(ctx context.Context, req *logical.Request, _ *fra
 }
 
 // GetPublicKeys returns a set of JSON Web Keys.
-func (b *backend) getPublicKeys(ctx context.Context, stg logical.Storage) (*jose.JSONWebKeySet, error) {
+func (b *backend) getPublicKeys(ctx context.Context, stg logical.Storage, mount string) (*jose.JSONWebKeySet, error) {
 
 	config, err := b.getConfig(ctx, stg)
 	if err != nil {
 		return nil, err
 	}
 
-	policy, err := b.getPolicy(ctx, stg, config)
+	policy, err := b.getPolicy(ctx, stg, config, mount)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/path_jwks_test.go
+++ b/plugin/path_jwks_test.go
@@ -30,9 +30,10 @@ import (
 func FetchJWKS(b *backend, storage *logical.Storage) (*jose.JSONWebKeySet, error) {
 
 	req := &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "jwks",
-		Storage:   *storage,
+		Operation:  logical.ReadOperation,
+		Path:       "jwks",
+		Storage:    *storage,
+		MountPoint: "test",
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)
@@ -70,7 +71,7 @@ func TestJwks(t *testing.T) {
 		t.Fatalf("err:%s\n", err)
 	}
 
-	expectedKeySet, err := b.getPublicKeys(context.Background(), *storage)
+	expectedKeySet, err := b.getPublicKeys(context.Background(), *storage, "test")
 	if err != nil {
 		t.Fatalf("err: %#v", err)
 	}

--- a/plugin/path_roles_test.go
+++ b/plugin/path_roles_test.go
@@ -33,10 +33,11 @@ func writeRole(b *backend, storage *logical.Storage, name string, issuer string,
 	}
 
 	req := &logical.Request{
-		Operation: logical.CreateOperation,
-		Path:      "roles/" + name,
-		Storage:   *storage,
-		Data:      data,
+		Operation:  logical.CreateOperation,
+		Path:       "roles/" + name,
+		Storage:    *storage,
+		Data:       data,
+		MountPoint: "test",
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)
@@ -50,9 +51,10 @@ func writeRole(b *backend, storage *logical.Storage, name string, issuer string,
 func readRole(b *backend, storage *logical.Storage, name string) (*logical.Response, error) {
 
 	req := &logical.Request{
-		Operation: logical.ReadOperation,
-		Path:      "roles/" + name,
-		Storage:   *storage,
+		Operation:  logical.ReadOperation,
+		Path:       "roles/" + name,
+		Storage:    *storage,
+		MountPoint: "test",
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)
@@ -222,9 +224,10 @@ func TestList(t *testing.T) {
 	}
 
 	req := &logical.Request{
-		Operation: logical.ListOperation,
-		Path:      "roles",
-		Storage:   *storage,
+		Operation:  logical.ListOperation,
+		Path:       "roles",
+		Storage:    *storage,
+		MountPoint: "test",
 	}
 
 	resp, err := b.HandleRequest(context.Background(), req)
@@ -252,9 +255,10 @@ func TestDelete(t *testing.T) {
 	}
 
 	req := &logical.Request{
-		Operation: logical.DeleteOperation,
-		Path:      "roles/" + role,
-		Storage:   *storage,
+		Operation:  logical.DeleteOperation,
+		Path:       "roles/" + role,
+		Storage:    *storage,
+		MountPoint: "test",
 	}
 
 	if _, err := b.HandleRequest(context.Background(), req); err != nil {

--- a/plugin/path_sign.go
+++ b/plugin/path_sign.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 	"regexp"
+	"time"
 )
 
 const (
@@ -98,7 +99,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 
 	claims["iss"] = role.Issuer
 
-	now := b.clock.now()
+	now := time.Now()
 
 	expiry := now.Add(config.TokenTTL)
 	claims["exp"] = jwt.NumericDate(expiry.Unix())
@@ -162,7 +163,7 @@ func (b *backend) pathSignWrite(ctx context.Context, req *logical.Request, d *fr
 		}
 	}
 
-	policy, err := b.getPolicy(ctx, req.Storage, config)
+	policy, err := b.getPolicy(ctx, req.Storage, config, req.MountPoint)
 	if err != nil {
 		return logical.ErrorResponse("error getting key: %v", err), err
 	}

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -27,27 +27,6 @@ import (
 	"github.com/mariuszs/friendlyid-go/friendlyid"
 )
 
-// clock is an interface for obtaining the current time.
-type clock interface {
-	now() time.Time
-}
-
-// realClock is a clock which returns the actual current time.
-type realClock struct{}
-
-func (r realClock) now() time.Time {
-	return time.Now()
-}
-
-// fakeClock is a clock which can be used for testing.
-type fakeClock struct {
-	Instant time.Time
-}
-
-func (f fakeClock) now() time.Time {
-	return f.Instant
-}
-
 // uniqueIdGenerator is an interface for generating unique ids.
 type uniqueIdGenerator interface {
 	id() (string, error)


### PR DESCRIPTION
Correctly sets `MinDecryptionVersion` on policy to ensure expired keys are deleted

Also
* Removese `clock` from backend, cannot inject into Policy functions and thus makes it _hard_ to use for testing things like rotation and pruning.
* Logs the mount (not key name) during rotation; required adding “mount” to chain of calling functions