### PR TITLE
EdDSA Algorithm Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ verification as long as any JWTs signed with them are valid.
 The plugin supports a subset of the asymmetric encryption algorithms outlined in the JWT
 specification.
 
+* EdDSA
 * ES256
 * ES384
 * ES512

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/vault/api v1.10.0
 	github.com/hashicorp/vault/sdk v0.10.2
 	github.com/mariuszs/friendlyid-go v0.0.0-20200911181514-555cced97798
+	golang.org/x/crypto v0.12.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 )
 
@@ -65,7 +66,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/stretchr/testify v1.8.3 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
 	golang.org/x/mod v0.9.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect

--- a/plugin/backend.go
+++ b/plugin/backend.go
@@ -169,6 +169,8 @@ func (b *backend) getPolicy(ctx context.Context, stg logical.Storage, config *Co
 		default:
 			err = errutil.InternalError{Err: "unsupported RSA key size"}
 		}
+	case jose.EdDSA:
+		polReq.KeyType = keysutil.KeyType_ED25519
 	case jose.ES256:
 		polReq.KeyType = keysutil.KeyType_ECDSA_P256
 	case jose.ES384:

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -48,7 +48,7 @@ var DefaultAllowedClaims = []string{"sub", "aud"}
 var ReservedClaims = []string{"iss", "exp", "nbf", "iat", "jti"}
 var ReservedHeaders = []string{"kid", "alg", "enc", "zip", "crit"}
 
-var AllowedSignatureAlgorithmNames = []string{string(jose.ES256), string(jose.ES384), string(jose.ES512), string(jose.RS256), string(jose.RS384), string(jose.RS512)}
+var AllowedSignatureAlgorithmNames = []string{string(jose.EdDSA), string(jose.ES256), string(jose.ES384), string(jose.ES512), string(jose.RS256), string(jose.RS384), string(jose.RS512)}
 var AllowedRSAKeyBits = []int{2048, 3072, 4096}
 
 // Config holds all configuration for the backend.
@@ -186,6 +186,8 @@ func (b *backend) saveConfig(ctx context.Context, stg logical.Storage, config *C
 		default:
 			err = errutil.InternalError{Err: "unsupported RSA key size"}
 		}
+	case jose.EdDSA:
+		policy.Type = keysutil.KeyType_ED25519
 	case jose.ES256:
 		policy.Type = keysutil.KeyType_ECDSA_P256
 	case jose.ES384:


### PR DESCRIPTION
Hello @kdubb,

Thank you for maintaining this plugin! This PR adds end to end support for the `EdDSA` signature algorithm using the `ED25519` curve, as specified in [RFC 8037](https://www.rfc-editor.org/rfc/rfc8037). To use it, specify `EdDSA` as the `sig_alg` in the config.


Use case: I wanted to use this plugin to manage service account tokens in my cluster. I had a specific requirement that the JWTs use the `EdDSA` signature algorithm.

Example output:

```sh
curl -i http://localhost:8200/v1/jwt/jwks
HTTP/2 200
cache-control: no-store
content-type: application/jwk-set+json
strict-transport-security: max-age=31536000; includeSubDomains
content-length: 294
date: Thu, 17 Oct 2024 22:23:07 GMT

{"keys":[{"use":"sig","kty":"OKP","kid":"_h0PmyOGrVDz_UigcHe8OVD27_o","crv":"Ed25519","alg":"EdDSA","x":"exyyS0587hKfD7tWTZmVj4KykNMnAwGqRckevoM1xm4"},{"use":"sig","kty":"OKP","kid":"dRq7Fm6Z
l8YzIwbiJq26sjlZJis","crv":"Ed25519","alg":"EdDSA","x":"O8WwHreDBmCf7RBr3hirBciavQLUFyJ5jbwJuaf3Ewo"}]}⏎
```

```sh
vault write -f /helium-jwt/sign/admin
Key                Value
---                -----
lease_id           jwt/sign/admin/obise6joPAKqgGZg8HeSBS9L
lease_duration     720h
lease_renewable    false
token              eyJhbGciOiJFZERTQSIsImtpZCI6ImRScTdGbTZabDhZekl3YmlKcTI2c2psWkppcyIsInR5cCI6IkpXVCJ9....
```